### PR TITLE
Unexpected any types fixed to required type.

### DIFF
--- a/ClientApp/src/app/hashtag-page/hashtag-page.service.ts
+++ b/ClientApp/src/app/hashtag-page/hashtag-page.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { ServiceResponse } from 'src/shared/service-response.model';
+import { BlogPost } from '../post-list/post-model';
 
 @Injectable({
   providedIn: 'root'
@@ -11,6 +12,6 @@ export class HashtagPageService {
   constructor(private _http: HttpClient, @Inject('BASE_URL') private baseUrl: string) { }
 
   SearchHashtags(searchInput: string) {
-    return this._http.get<ServiceResponse<any>>(this.baseUrl + environment.searchHashtags + searchInput);
+    return this._http.get<ServiceResponse<BlogPost[]>>(this.baseUrl + environment.searchHashtags + searchInput);
   }
 }

--- a/ClientApp/src/app/post-list/post-list.service.ts
+++ b/ClientApp/src/app/post-list/post-list.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { ServiceResponse } from 'src/shared/service-response.model';
+import { BlogPost } from './post-model';
 
 @Injectable({
   providedIn: 'root'
@@ -11,6 +12,6 @@ export class PostListService {
   constructor(private _http: HttpClient, @Inject('BASE_URL') private baseUrl: string) { }
 
   GetAllPosts() {
-    return this._http.get<ServiceResponse<any>>(this.baseUrl + environment.getAllPosts);
+    return this._http.get<ServiceResponse<BlogPost[]>>(this.baseUrl + environment.getAllPosts);
   }
 }

--- a/ClientApp/src/app/search-page/search-page.service.ts
+++ b/ClientApp/src/app/search-page/search-page.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { ServiceResponse } from 'src/shared/service-response.model';
+import { BlogPost } from '../post-list/post-model';
 
 @Injectable({
   providedIn: 'root'
@@ -11,6 +12,6 @@ export class SearchPageService {
   constructor(private _http: HttpClient, @Inject('BASE_URL') private baseUrl: string) { }
 
   SearchPosts(searchInput: string) {
-    return this._http.get<ServiceResponse<any>>(this.baseUrl + environment.searchPosts + searchInput);
+    return this._http.get<ServiceResponse<BlogPost[]>>(this.baseUrl + environment.searchPosts + searchInput);
   }
 }

--- a/ClientApp/src/app/single-post/single-post.service.ts
+++ b/ClientApp/src/app/single-post/single-post.service.ts
@@ -2,6 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
 import { environment } from 'src/environments/environment';
 import { ServiceResponse } from 'src/shared/service-response.model';
+import { BlogPost } from '../post-list/post-model';
 
 @Injectable({
   providedIn: 'root'
@@ -11,6 +12,6 @@ export class SinglePostService {
   constructor(private _http: HttpClient, @Inject('BASE_URL') private baseUrl: string) { }
 
   GetPostByLink(link: string) {
-    return this._http.get<ServiceResponse<any>>(this.baseUrl + environment.getPostByLink + link);
+    return this._http.get<ServiceResponse<BlogPost>>(this.baseUrl + environment.getPostByLink + link);
   }
 }


### PR DESCRIPTION
Using the any type defeats the purpose of using TypeScript. When any is used, all compiler type checks around that value are ignored.
https://typescript-eslint.io/rules/no-explicit-any/