### PR TITLE
A closing curly bracket must not be preceded by a blank line.

### DIFF
--- a/Controllers/BlogPostController.cs
+++ b/Controllers/BlogPostController.cs
@@ -11,8 +11,8 @@ namespace bilog.Controllers
         public BlogPostController(IBlogPostService blogPostService)
         {
             _blogPostService = blogPostService;
-
         }
+
         [HttpGet("getall")]
         public async Task<IActionResult> GetAllBlogPosts()
         {
@@ -30,6 +30,7 @@ namespace bilog.Controllers
         {
             return Ok(await _blogPostService.SearchPosts(searchInput));
         }
+
         [HttpGet("hashtag/{searchInput}")]
         public async Task<IActionResult> SearchHashtagPosts(string searchInput)
         {

--- a/Controllers/UserController.cs
+++ b/Controllers/UserController.cs
@@ -16,7 +16,6 @@ namespace bilog.Controllers
             _userService = userService;
         }
 
-
         [AllowAnonymous]
         [HttpPost("Register")]
         public async Task<IActionResult> Register(UserRegisterDto request)

--- a/Data/DataContext.cs
+++ b/Data/DataContext.cs
@@ -8,9 +8,9 @@ namespace bilog.Data
         public DataContext(DbContextOptions<DataContext> options) : base(options)
         {
         }
+
         public DbSet<User> Users { get; set; }
         public DbSet<BlogPost> BlogPosts { get; set; }
         public DbSet<Category> Categories { get; set; }
-
     }
 }

--- a/Models/BlogPost.cs
+++ b/Models/BlogPost.cs
@@ -10,6 +10,5 @@ namespace bilog.Models
         public string FeaturedImage { get; set; }
         public List<Category>? Categories { get; set; }
         public User Author { get; set; }
-
     }
 }

--- a/Services/BlogPostService/BlogPostService.cs
+++ b/Services/BlogPostService/BlogPostService.cs
@@ -125,8 +125,6 @@ namespace bilog.Services.BlogPostService
                 }
 
                 blogPosts = category.BlogPosts;
-
-
                 if (blogPosts == null)
                 {
                     response.Success = false;

--- a/Services/BlogPostService/IBlogPostService.cs
+++ b/Services/BlogPostService/IBlogPostService.cs
@@ -9,6 +9,5 @@ namespace bilog.Services.BlogPostService
         Task<ServiceResponse<List<BlogPost>>> GetAllPosts();
         Task<ServiceResponse<List<BlogPost>>> SearchPosts(string searchInput);
         Task<ServiceResponse<List<BlogPost>>> SearchHashtags(string searchInput);
-
     }
 }

--- a/Services/UserService/UserService.cs
+++ b/Services/UserService/UserService.cs
@@ -20,8 +20,8 @@ namespace bilog.Services.UserService
             _configuration = configuration;
             _regexUtilities = regexUtilities;
             _context = context;
-
         }
+
         public async Task<ServiceResponse<string>> Login(string email, string password)
         {
             ServiceResponse<string> response = new ServiceResponse<string>();
@@ -58,7 +58,6 @@ namespace bilog.Services.UserService
                 {
                     response.Data = CreateToken(user);
                 }
-
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
To improve the readability of the code, StyleCop requires blank lines in certain situations, and prohibits blank lines in other situations. This results in a consistent visual pattern across the code, which can improve recognition and readability of unfamiliar code.
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md